### PR TITLE
Implement QMod Repo

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Get username and repository
         run: |
           echo "REPO_USERNAME=${GITHUB_REPOSITORY%%/*}" >> $GITHUB_ENV

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,6 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Combine json
         run: "cd scripts && npm install && npx tsx ./combine.ts --skipHashes"
 

--- a/.github/workflows/update-cores.yml
+++ b/.github/workflows/update-cores.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Update the core mods
         run: |
           cd scripts
@@ -38,7 +42,7 @@ jobs:
         run: |
           git add -A mods
           (
-            git commit -m "Update core mods (Automated)" && 
+            git commit -m "Update core mods (Automated)" &&
             (
               echo "MODS_UPDATED=yes" >> $GITHUB_ENV
             )

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 website/public/covers
 website/public/mods.json
+website/public/qmod_repo
 website/public/sha1sums.json
 **/node_modules
 qmods

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A test repo for beat saber quest mods",
   "main": "combine.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/scripts/shared/paths.ts
+++ b/scripts/shared/paths.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
 /** The base path of the git repo */
-export const repoDir = path.join(__dirname, "..", "..");
+export const repoDir = path.join(import.meta.dirname, "..", "..");
 
 /** The path to the mods folder */
 export const modsPath = path.join(repoDir, "mods");
@@ -13,10 +13,13 @@ export const coversPath = path.join(repoDir, "website", "public", "covers");
 export const hashesPath = path.join(repoDir, "website", "public", "sha1sums.json");
 
 /** The path to the qmod download cache */
-export const qmodsPath = path.join(__dirname, "..", "qmods");
+export const qmodsPath = path.join(import.meta.dirname, "..", "qmods");
 
 /** The path to the combined mods.json file */
 export const allModsPath = path.join(repoDir, "website", "public", "mods.json");
+
+/** The path to the combined mods.json file */
+export const qmodRepoDirPath = path.join(repoDir, "website", "public", "qmod_repo");
 
 /** The path to the imported.json file used to track which core mods have been imported */
 export const importedCoreModsInfo = path.join(modsPath, "imported.json")

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -2,16 +2,14 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "strict": true,
-    "target": "ESNext",
+    "target": "ES2021",
     "experimentalDecorators": false,
     "inlineSourceMap": true,
     "isolatedModules": true,
     "jsx": "react",
-    "lib": ["DOM", "DOM.AsyncIterable", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
+    "lib": ["DOM", "DOM.AsyncIterable", "DOM.Iterable", "ES2021"],
+    "module": "esnext",
     "moduleDetection": "force",
-    "useDefineForClassFields": true,
-    "moduleResolution": "Bundler",
-    
+    "useDefineForClassFields": true
   }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,6 +10,7 @@
         "@astrojs/check": "^0.7.0",
         "@astrojs/react": "^3.6.0",
         "@astrojs/tailwind": "^5.1.0",
+        "@astrojs/ts-plugin": "^1.8.0",
         "@heroicons/react": "^2.1.4",
         "@playform/compress": "^0.0.13",
         "@tailwindcss/typography": "github:tailwindcss/typography",
@@ -201,6 +202,20 @@
       },
       "engines": {
         "node": "^18.17.1 || ^20.3.0 || >=21.0.0"
+      }
+    },
+    "node_modules/@astrojs/ts-plugin": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/ts-plugin/-/ts-plugin-1.8.0.tgz",
+      "integrity": "sha512-SXbMemCjA66eHXLon2uDGkLAdbIRS+EzSBKPqBuOcQ4XzU/o+oTTp12cXBIQTOtP/zsnuJPYA6gc36Ylic196g==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.7.0",
+        "@jridgewell/sourcemap-codec": "^1.4.15",
+        "@volar/language-core": "~2.2.3",
+        "@volar/typescript": "~2.2.3",
+        "semver": "^7.3.8",
+        "vscode-languageserver-textdocument": "^1.0.11"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,7 @@
     "@astrojs/check": "^0.7.0",
     "@astrojs/react": "^3.6.0",
     "@astrojs/tailwind": "^5.1.0",
+    "@astrojs/ts-plugin": "^1.8.0",
     "@heroicons/react": "^2.1.4",
     "@playform/compress": "^0.0.13",
     "@tailwindcss/typography": "github:tailwindcss/typography",

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -7,6 +7,12 @@
   ],
   "compilerOptions": {
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "strict": true,
+    "plugins": [
+      {
+        "name": "@astrojs/ts-plugin"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This PR implements a `qmod_repo/${game_version}` JSON endpoint which shows all the available mods for the version.

The idea behind this is to allow mod managers such as ModsBeforeFriday and BMBF to update dependencies (or display mod updates) without requiring knowledge of the updated dependency beforehand. Essentially, it can lookup newer versions with no aforementioned knowledge of the version or even provocation to update the dependency.

It looks more or less like this:

`Map<mod_id: String, Map<mod_version: String, mod_object: Mod>>`
```json5
{
  "chroma": {
    "2.9.0": {
      "name": "Chroma",
      "description": "Colors!",
      "id": "chroma",
      "version": "2.9.0",
      "author": "Aeroluna, FernTheDev, nyamimi~",
      "modloader": "Scotland2",
      "download": "https://github.com/bsq-ports/Chroma/releases/download/v2.9.0/Chroma.qmod",
      "source": "https://github.com/bsq-ports/Chroma/",
      "cover": null,
      "funding": null,
      "website": null
    },
    "2.9.1": {
      "name": "Chroma",
      "description": "Colors!",
      "id": "chroma",
      "version": "2.9.1",
      "author": "Aeroluna, FernTheDev, nyamimi~",
      "modloader": "Scotland2",
      "download": "https://github.com/bsq-ports/Chroma/releases/download/v2.9.1/Chroma.qmod",
      "source": "https://github.com/bsq-ports/Chroma/",
      "cover": null,
      "funding": null,
      "website": null
    },
    "2.9.2": {
      "name": "Chroma",
      "description": "Colors!",
      "id": "chroma",
      "version": "2.9.2",
      "author": "Aeroluna, FernTheDev, nyamimi~",
      "modloader": "Scotland2",
      "download": "https://github.com/bsq-ports/Chroma/releases/download/v2.9.2/Chroma.qmod",
      "source": "https://github.com/bsq-ports/Chroma/",
      "cover": null,
      "funding": null,
      "website": null
    }
  },
}
```

This was discussed beforehand with @lauriethefish.